### PR TITLE
add snapshot checking before format the volume

### DIFF
--- a/package/ebs/rancher-ebs
+++ b/package/ebs/rancher-ebs
@@ -171,9 +171,12 @@ create() {
         print_error $device_path
     fi
 
-    error=`mkfs.ext4 -F $device_path 2>&1`
-    if [ $? -ne 0 ]; then
-        print_error $error
+    # don't format the volume if snapshot is set
+    if [ -z "${snapshot}" ]; then
+        error=`mkfs.ext4 -F $device_path 2>&1`
+        if [ $? -ne 0 ]; then
+            print_error $error
+        fi
     fi
 
     do_detach $device_path


### PR DESCRIPTION
I tested your commits to rancher/storage, it's working fine, thanks, for our company encryption volumes is very need function. But I found one issue, if we use snapshots after created and attached the volume to the host it will be formatted and we get the clean volume inside docker container. I added simple check, could you see please?